### PR TITLE
Increase WGET retry number for Spark dowload

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -832,6 +832,7 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
+                  <retries>5</retries>
                   <url>${spark.download.url}</url>
                   <outputDirectory>${spark.dist.cache}</outputDirectory>
                 </configuration>


### PR DESCRIPTION
2 -> 5 to avoid CI failures